### PR TITLE
Handling of conversion of nullable data types (https://stackoverflow.…

### DIFF
--- a/src/Nettle/Common/Conversion/GenericObjectToTypeConverter.cs
+++ b/src/Nettle/Common/Conversion/GenericObjectToTypeConverter.cs
@@ -36,11 +36,13 @@
 
                 if (canConvert)
                 {
-                    return (T)System.Convert.ChangeType
-                    (
-                        value,
-                        typeof(T)
-                    );
+	                var t = typeof(T);
+	                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>))
+	                {
+		                t = Nullable.GetUnderlyingType(t);
+	                }
+
+	                return (T)System.Convert.ChangeType(value, t);
                 }
                 else if (value.GetType() == typeof(string))
                 {


### PR DESCRIPTION
Hello,

Now I made a fork of Nettle, committed to that fork and now I try to make the pull request that way. 

Anyway, I modified a tiny bit of code according to a solution I found in the below Stack Overflow page (https://stackoverflow.com/questions/18015425/invalid-cast-from-system-int32-to-system-nullable1system-int32-mscorlib): 

It is regarding conversion of nullable types. And for me it fixed the problem of trying to retrieve a <decimal?> type inside a custom function.

My custom function that threw the error looks like this:

```
using System.Globalization;
using Nettle;
using Nettle.Compiler;
using Nettle.Functions;

namespace Global.CustomerNotifier.HtmlServices.Builders.Soa.NettleFunctions
{
	public sealed class FormatDecimalOrNullFunction : FunctionBase
	{
		public FormatDecimalOrNullFunction() : base()
		{
			DefineRequiredParameter
			(
				"Number",
				"The decimal number to format",
				typeof(decimal?)
			);
			DefineRequiredParameter
			(
				"Format",
				"The format to apply",
				typeof(string)
			);
		}
		protected override object GenerateOutput(TemplateContext context, params object[] parameterValues)
		{
			Validate.IsNotNull(context);

			var number = GetParameterValue<decimal?>
			(
				"Number",
				parameterValues
			);
			var format = GetParameterValue<string>
			(
				"Format",
				parameterValues
			);

			return number?.ToString(format, new CultureInfo("en-GB")) ?? "";
		}

		public override string Description => "Formats a nullable decimal value.";
	}
}

```

So if you make this into a custom function and try to feed it with an object that contains a <decimal?> type, it should throw an error before the fix and not throw an error after :-)
